### PR TITLE
Specifies cilium as default network_data_plane

### DIFF
--- a/aks/aks-terraform/aks-cilium/main.tf
+++ b/aks/aks-terraform/aks-cilium/main.tf
@@ -18,8 +18,9 @@ resource "azurerm_kubernetes_cluster" "k8squickstart" {
   dns_prefix          = "${var.name}-dns01"
 
   network_profile {
-  network_plugin = "azure"
-  network_policy = "cilium"
+  network_plugin     = "azure"
+  network_policy     = "cilium"
+  network_data_plane = "cilium"
 }
 
   default_node_pool {

--- a/aks/aks-terraform/aks-cilium/main.tf
+++ b/aks/aks-terraform/aks-cilium/main.tf
@@ -18,9 +18,10 @@ resource "azurerm_kubernetes_cluster" "k8squickstart" {
   dns_prefix          = "${var.name}-dns01"
 
   network_profile {
-  network_plugin     = "azure"
-  network_policy     = "cilium"
-  network_data_plane = "cilium"
+  network_plugin       = "azure"
+  network_plugin_mode  = "overlay"
+  network_policy       = "cilium"
+  network_data_plane   = "cilium"
 }
 
   default_node_pool {


### PR DESCRIPTION
Addresses issue in #1 seen with conflict between `network_data_plane` and `network_policy` when `network_policy` is `cilium` and `network_data_plane` isn't specified. 

`network_plugin_mode` was set to `overlay` to avoid additional 400 error when creating AKS cluster. 

* [`aks/aks-terraform/aks-cilium/main.tf`](diffhunk://#diff-aeae13c0799db85814113738d1a0a6e95b3e02c237e694aaf4020aac9cf323daR22-R24): Added `network_plugin_mode` set to "overlay" and `network_data_plane` set to "cilium" in the `network_profile` block to improve network configuration.